### PR TITLE
change return type to be Result<(), VerifyError> for verify()

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -35,3 +35,16 @@ pub enum ValidationError {
     /// A type conversion failed during validation e.g overflow
     Conversion,
 }
+
+/// A signature verification error
+#[cfg_attr(feature = "std", derive(PartialEq, Debug))]
+pub enum VerifyError {
+    /// Unsupported signature version
+    UnsupportedVersion,
+    /// Signature format is invalid
+    BadSignatureFormat,
+    /// PublicKey format is invalid
+    BadPublicKeyFormat,
+    /// The signature does not verify the payload from signer
+    Invalid,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;

--- a/src/signature/mod.rs
+++ b/src/signature/mod.rs
@@ -34,8 +34,8 @@ impl TryFrom<u8> for SignatureVersion {
 }
 
 /// A signature verification error
-#[cfg_attr(feature = "std", derive(Debug))]
-enum VerifyError {
+#[cfg_attr(feature = "std", derive(PartialEq, Debug))]
+pub enum VerifyError {
     /// Unsupported signature version
     UnsupportedVersion,
     /// Signature format is invalid
@@ -46,13 +46,17 @@ enum VerifyError {
     Invalid,
 }
 
-// TODO: Expose `Result` instead of bool
 /// Verify the signature for a DoughnutApi impl type
-pub fn verify_signature(signature: &[u8], version: u8, signer: &[u8], payload: &[u8]) -> bool {
+pub fn verify_signature(
+    signature: &[u8],
+    version: u8,
+    signer: &[u8],
+    payload: &[u8],
+) -> Result<(), VerifyError> {
     let _version = SignatureVersion::try_from(version).map_err(|_| return false);
     match _version.unwrap() {
-        SignatureVersion::Sr25519 => verify_sr25519_signature(signature, signer, payload).is_ok(),
-        SignatureVersion::Ed25519 => verify_ed25519_signature(signature, signer, payload).is_ok(),
+        SignatureVersion::Sr25519 => verify_sr25519_signature(signature, signer, payload),
+        SignatureVersion::Ed25519 => verify_ed25519_signature(signature, signer, payload),
     }
 }
 

--- a/src/signature/mod.rs
+++ b/src/signature/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::error::VerifyError;
 use core::convert::TryFrom;
 use ed25519_dalek::{PublicKey as Ed25519Pub, Signature as Ed25519Sig};
 use schnorrkel::{signing_context, PublicKey as Sr25519Pub, Signature as Sr25519Sig};
@@ -31,19 +32,6 @@ impl TryFrom<u8> for SignatureVersion {
             _ => Err(VerifyError::UnsupportedVersion),
         }
     }
-}
-
-/// A signature verification error
-#[cfg_attr(feature = "std", derive(PartialEq, Debug))]
-pub enum VerifyError {
-    /// Unsupported signature version
-    UnsupportedVersion,
-    /// Signature format is invalid
-    BadSignatureFormat,
-    /// PublicKey format is invalid
-    BadPublicKeyFormat,
-    /// The signature does not verify the payload from signer
-    Invalid,
 }
 
 /// Verify the signature for a DoughnutApi impl type

--- a/src/traits/impls.rs
+++ b/src/traits/impls.rs
@@ -15,8 +15,7 @@
 //! Doughnut trait impls
 //!
 use crate::alloc::vec::Vec;
-use crate::error::ValidationError;
-use crate::signature::VerifyError;
+use crate::error::{ValidationError, VerifyError};
 use crate::traits::{DoughnutApi, DoughnutVerify};
 
 #[cfg(feature = "std")]

--- a/src/traits/impls.rs
+++ b/src/traits/impls.rs
@@ -16,6 +16,7 @@
 //!
 use crate::alloc::vec::Vec;
 use crate::error::ValidationError;
+use crate::signature::VerifyError;
 use crate::traits::{DoughnutApi, DoughnutVerify};
 
 #[cfg(feature = "std")]
@@ -59,14 +60,14 @@ impl DoughnutApi for () {
 }
 
 impl DoughnutVerify for () {
-    fn verify(&self) -> bool {
-        true
+    fn verify(&self) -> Result<(), VerifyError> {
+        Ok(())
     }
 }
 
 #[cfg(feature = "std")]
 impl<'a> DoughnutVerify for DoughnutV0<'a> {
-    fn verify(&self) -> bool {
+    fn verify(&self) -> Result<(), VerifyError> {
         verify_signature(
             self.signature().as_ref(),
             self.signature_version(),
@@ -78,7 +79,7 @@ impl<'a> DoughnutVerify for DoughnutV0<'a> {
 
 #[cfg(feature = "std")]
 impl DoughnutVerify for ParityDoughnutV0 {
-    fn verify(&self) -> bool {
+    fn verify(&self) -> Result<(), VerifyError> {
         verify_signature(
             &self.signature.as_ref(),
             self.signature_version(),
@@ -109,7 +110,7 @@ mod test {
         ];
         let doughnut: ParityDoughnutV0 =
             Decode::decode(&mut &encoded[..]).expect("It is a valid doughnut");
-        assert!(doughnut.verify());
+        assert_eq!(doughnut.verify(), Ok(()));
     }
 
     #[test]
@@ -127,7 +128,7 @@ mod test {
         ];
         let doughnut: ParityDoughnutV0 =
             Decode::decode(&mut &encoded[..]).expect("It is a valid doughnut");
-        assert!(!doughnut.verify());
+        assert_eq!(doughnut.verify(), Err(VerifyError::Invalid));
     }
 
     #[test]
@@ -145,7 +146,7 @@ mod test {
         ];
         let doughnut: ParityDoughnutV0 =
             Decode::decode(&mut &encoded[..]).expect("It is a valid doughnut");
-        assert!(doughnut.verify());
+        assert_eq!(doughnut.verify(), Ok(()));
     }
 
     #[test]
@@ -163,6 +164,6 @@ mod test {
         ];
         let doughnut: ParityDoughnutV0 =
             Decode::decode(&mut &encoded[..]).expect("It is a valid doughnut");
-        assert!(!doughnut.verify());
+        assert_eq!(doughnut.verify(), Err(VerifyError::Invalid));
     }
 }

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -16,6 +16,7 @@
 //!
 use crate::alloc::vec::Vec;
 use crate::error::ValidationError;
+use crate::signature::VerifyError;
 use core::convert::TryInto;
 mod impls;
 
@@ -78,5 +79,5 @@ pub trait DoughnutApi {
 /// Provide doughnut signature checks
 pub trait DoughnutVerify {
     /// Verify the doughnut signature, return whether it is valid or not
-    fn verify(&self) -> bool;
+    fn verify(&self) -> Result<(), VerifyError>;
 }

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -15,8 +15,7 @@
 //! Doughnut traits
 //!
 use crate::alloc::vec::Vec;
-use crate::error::ValidationError;
-use crate::signature::VerifyError;
+use crate::error::{ValidationError, VerifyError};
 use core::convert::TryInto;
 mod impls;
 


### PR DESCRIPTION
Changes:
- move `VerifyError` from signature to error module
- change return type of `verify_sr25519_signature()` to be `Result<(), VerifyError>`
- change return type o `verify_ed25519_signature()` to be `Result<(), VerifyError>`
- change to `assert_eq!` macro for tests accordingly

Closes #22 