### PR TITLE
Always derive Debug on doughnut structs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,13 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/rust:1.36.0
+      - image: circleci/rust:1.38.0
     steps:
       - checkout
       - run:
           name: setup
           command: |
-            rustup component add rustfmt --toolchain 1.36.0-x86_64-unknown-linux-gnu
+            rustup component add rustfmt
             rustup install nightly
       - run:
           name: cargo build

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 /// Error type for codec failures
-#[cfg_attr(feature = "std", derive(Debug))]
-#[derive(PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub enum CodecError<'a> {
     /// The doughnut version is unsupported by the current codec
     UnsupportedVersion,
@@ -23,8 +22,7 @@ pub enum CodecError<'a> {
 }
 
 /// Error type for validation failures
-#[cfg_attr(feature = "std", derive(Debug))]
-#[derive(PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub enum ValidationError {
     /// Public key attempting to use a doughnut does not match the issued holder
     HolderIdentityMismatched,

--- a/src/v0/mod.rs
+++ b/src/v0/mod.rs
@@ -21,10 +21,8 @@
 // in BE byte order.
 use bit_reverse::ParallelReverse;
 use codec::Encode;
+use core::fmt::{self};
 use core::ptr;
-
-#[cfg(feature = "std")]
-use alloc::fmt;
 
 use crate::alloc::vec::Vec;
 use crate::error::CodecError;
@@ -40,8 +38,7 @@ const WITH_NOT_BEFORE_OFFSET: u8 = 75;
 const SIGNATURE_MASK: u8 = 0b0001_1111;
 const NOT_BEFORE_MASK: u8 = 0b1000_0000;
 
-#[derive(PartialEq, Eq, Clone)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct DoughnutV0<'a>(&'a [u8]);
 
 impl<'a> DoughnutApi for DoughnutV0<'a> {
@@ -154,7 +151,6 @@ fn has_not_before(buf: &[u8]) -> bool {
     (buf[2] & NOT_BEFORE_MASK) == NOT_BEFORE_MASK
 }
 
-#[cfg(feature = "std")]
 impl<'a> fmt::Display for DoughnutV0<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(

--- a/src/v0/parity.rs
+++ b/src/v0/parity.rs
@@ -31,8 +31,7 @@ use crate::traits::DoughnutApi;
 const NOT_BEFORE_MASK: u8 = 0b1000_0000;
 const SIGNATURE_MASK: u8 = 0b0001_1111;
 
-#[derive(Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct DoughnutV0 {
     pub issuer: [u8; 32],
     pub holder: [u8; 32],


### PR DESCRIPTION
Debug is needed regardless of std/no_std for new substrate updates

- Bumped CI version to stable `1.38.0` as a formatting rule seems to have changed between 1.36.0 and 1.38.0

Closes #27 