### PR TITLE
Hotfix/payload version

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -67,7 +67,7 @@ fn it_works_v0() {
 #[test]
 fn it_works_v0_parity() {
     let payload: Vec<u8> = vec![
-        0, 0, 64, 22, 126, 150, 15, 176, 190, 210, 156, 179, 149, 142, 84, 153, 4, 203, 61, 62,
+        64, 24, 64, 22, 126, 150, 15, 176, 190, 210, 156, 179, 149, 142, 84, 153, 4, 203, 61, 62,
         185, 76, 45, 162, 220, 254, 188, 163, 187, 63, 39, 186, 113, 126, 12, 60, 121, 179, 67,
         105, 121, 244, 39, 137, 174, 55, 85, 167, 73, 111, 50, 249, 10, 145, 141, 125, 105, 138,
         38, 93, 144, 45, 224, 70, 206, 246, 116, 196, 94, 16, 0, 115, 111, 109, 101, 116, 104, 105,
@@ -79,8 +79,8 @@ fn it_works_v0_parity() {
     ];
     let d = v0::parity::DoughnutV0::decode(&mut &payload[..]).expect("It works");
 
-    assert_eq!(d.signature_version, 0);
-    assert_eq!(d.payload_version, 0);
+    assert_eq!(d.signature_version, 3);
+    assert_eq!(d.payload_version, 2);
     assert_eq!(d.expiry, 555_555);
     assert_eq!(d.not_before, 0);
     assert_eq!(

--- a/src/v0/parity.rs
+++ b/src/v0/parity.rs
@@ -179,9 +179,10 @@ impl Decode for DoughnutV0 {
 impl Encode for DoughnutV0 {
     fn encode_to<T: Output>(&self, dest: &mut T) {
         let mut payload_version_and_signature_version = self.payload_version.swap_bits();
+
         payload_version_and_signature_version |=
-            (u16::from(self.signature_version) << 3).swap_bits();
-        dest.write(&payload_version_and_signature_version.to_le_bytes());
+            u16::from(self.signature_version).swap_bits() >> 11;
+        dest.write(&payload_version_and_signature_version.to_be_bytes());
 
         let mut domain_count_and_not_before_byte =
             (((self.domains.len() as u8) - 1) << 1).swap_bits();


### PR DESCRIPTION
Fix the bug of encoding `payload_version` and `signature_version` in doughnut parity v0