### PR TITLE
Explicit encode zero

### DIFF
--- a/src/doughnut/mod.rs
+++ b/src/doughnut/mod.rs
@@ -39,7 +39,7 @@ mod test {
             holder: [2_u8; 32],
             domains,
             expiry: 0,
-            not_before: 0,
+            not_before: None,
             payload_version: 3,
             signature_version: 3,
             signature: H512::default(),

--- a/src/test.rs
+++ b/src/test.rs
@@ -73,7 +73,7 @@ fn it_works_v0_parity() {
     assert_eq!(d.signature_version, 3);
     assert_eq!(d.payload_version, 2);
     assert_eq!(d.expiry, 555_555);
-    assert_eq!(d.not_before, 0);
+    assert_eq!(d.not_before, None);
     assert_eq!(
         d.issuer().as_ref(),
         [
@@ -171,7 +171,7 @@ fn it_works_doughnut_enum_v0_parity() {
     assert_eq!(d.signature_version, 3);
     assert_eq!(d.payload_version, 2);
     assert_eq!(d.expiry, 555_555);
-    assert_eq!(d.not_before, 0);
+    assert_eq!(d.not_before, None);
     assert_eq!(d.encode(), payload[1..].to_vec());
     assert_eq!(doughnut.encode(), payload);
 }

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -36,6 +36,11 @@ pub trait DoughnutApi {
     /// Return the payload for domain, if it exists in the doughnut
     fn get_domain(&self, domain: &str) -> Option<&[u8]>;
     /// Validate the doughnut is usable by a public key (`who`) at the current timestamp (`not_before` <= `now` <= `expiry`)
+    /// # Errors
+    /// This function will error if the doughnut is invalid for use given `who` and the timestamp `now`
+    /// It may also fail on type conversions if:
+    /// - `who` cannot be coerced into the doughnut public key type
+    /// - `now` cannot be coerced into the doughnut timestamp type
     fn validate<Q, R>(&self, who: Q, now: R) -> Result<(), ValidationError>
     where
         Q: AsRef<[u8]>,
@@ -68,5 +73,9 @@ pub trait DoughnutApi {
 /// Provide doughnut signature checks
 pub trait DoughnutVerify {
     /// Verify the doughnut signature, return whether it is valid or not
+    ///
+    /// # Errors
+    /// This function may fail for any reason described by `VerifyError` variants
+    /// Primarily, the doughnut signature is invalid
     fn verify(&self) -> Result<(), VerifyError>;
 }


### PR DESCRIPTION
Fix an edge case where explicitly setting "not before" to 0 would not encode anything.
While this is optimal to encode nothing, it does not agree with the spec