### PR TITLE
Signature Unit Tests + Signature Verification Bug Fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,9 +142,9 @@ dependencies = [
  "ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,9 @@ dependencies = [
  "ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ primitive-types = { version = "<1.0", default-features = false }
 schnorrkel = { version = "^0.8.5", optional = true }
 ed25519-dalek = { version = "1.0.0-pre.1", optional = true }
 
+[dev-dependencies]
+rand = "0.7"
+sha2 = "0.8.1"
+
 [features]
 default = ["std"]
 std = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ schnorrkel = { version = "^0.8.5", optional = true }
 ed25519-dalek = { version = "1.0.0-pre.1", optional = true }
 
 [dev-dependencies]
-rand = "0.7"
-sha2 = "0.8.1"
+rand = "0.6"
+rand_core = "0.5.1"
 
 [features]
 default = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ extern crate std as alloc;
 #[cfg(test)]
 extern crate rand;
 #[cfg(test)]
-extern crate sha2;
+extern crate rand_core;
 
 mod doughnut;
 pub use doughnut::Doughnut;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,12 @@ extern crate alloc;
 #[macro_use]
 extern crate std as alloc;
 
+// for test only
+#[cfg(test)]
+extern crate rand;
+#[cfg(test)]
+extern crate sha2;
+
 mod doughnut;
 pub use doughnut::Doughnut;
 

--- a/src/signature/mod.rs
+++ b/src/signature/mod.rs
@@ -64,3 +64,38 @@ fn verify_sr25519_signature(
         .verify(signing_context(b"substrate").bytes(payload), &signature)
         .map_err(|_| VerifyError::Invalid)
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rand::rngs::OsRng;
+    use ed25519_dalek::Keypair as edKeypair;
+
+    #[test]
+    fn test_ed25519_signature_verifies() {
+        let mut csprng = OsRng{};
+        let keypair: edKeypair = edKeypair::generate(&mut csprng);
+        let payload = "To a deep sea diver who is swimming with a raincoat";
+        verify_ed25519_signature(
+                &keypair.sign(&payload.as_bytes()).to_bytes(),
+                &keypair.public.to_bytes(),
+                payload.as_bytes()
+            ).unwrap();
+    }
+
+    #[test]
+    fn test_ed25519_signature_does_not_verify() {
+        let mut csprng = OsRng{};
+        let keypair: edKeypair = edKeypair::generate(&mut csprng);
+        let payload = "To a deep sea diver who is swimming with a raincoat";
+        let signed_payload = "To a deep sea diver who is swimming without a raincoat";
+        assert_eq!(
+            verify_ed25519_signature(
+                &keypair.sign(&signed_payload.as_bytes()).to_bytes(),
+                &keypair.public.to_bytes(),
+                payload.as_bytes()
+            ),
+            Err(VerifyError::Invalid)
+        );
+    }
+}


### PR DESCRIPTION
A small PR to add unit tests to Doughnut signature verification

Fixes a bug where signature verification will panic when the signature version is not valid.

## Changes

* Exhaustive testing of signature verification functions
* Fixed bug in `verify_signature`

## Concerns

* None