### PR TITLE
Doughnut V0 Codec Fixes and Regression Tests

### DIFF
--- a/src/v0/parity.rs
+++ b/src/v0/parity.rs
@@ -216,12 +216,12 @@ impl Decode for DoughnutV0 {
             unsafe {
                 payload.set_len(payload_length);
             }
-            let _ = input.read(&mut payload)?;
+            input.read(&mut payload)?;
             domains.push((key, payload));
         }
 
         let mut signature = [0_u8; 64];
-        let _ = input.read(&mut signature)?;
+        input.read(&mut signature)?;
 
         if input.read_byte().is_ok() {
             Err(codec::Error::from("Doughnut contains unexpected bytes"))


### PR DESCRIPTION
Doughnut V0 Codec bug fixes and regression tests. This work was the result of a recent audit.

## Addresses:

* Insufficient unit testing around all of encoding and decoding

## Changes:

* Fix - doughnut no longer panics when encoding with 0 domains
* Fix - now provides decode error when there were not enough signature bytes
* Fix - now provides decode error when there are insufficient permission domain bytes
* Feature - now provides decode error when decoding a doughnut with excess bytes
* +8 encode/decode regression tests

## Concerns:

* None