### PR TITLE
Feat/no std crypto

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ commands:
 jobs:
   build:
     docker:
-      - image: circleci/rust:1.43.1
+      - image: circleci/rust:1.44.1
     steps:
       - checkout
       - run:
@@ -39,6 +39,8 @@ jobs:
       - run:
           name: cargo fmt
           command: |
+            rustup install nightly
+            rustup component add rustfmt --toolchain=nightly
             # use +nightly to enable license_template check
             cargo +nightly fmt --version
             cargo +nightly fmt -- --check
@@ -51,6 +53,7 @@ jobs:
           command: |
             cargo --version --verbose
             cargo check --no-default-features
+            cargo +nightly --version --verbose
             cargo +nightly check --no-default-features --features=crypto
       # JS
       - build-js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
           command: |
             # TODO: use +nightly to enable license_template check
             cargo fmt --version
-            cargo fmt --check
+            cargo fmt -- --check
       - run:
           name: cargo test
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,11 +39,9 @@ jobs:
       - run:
           name: cargo fmt
           command: |
-            rustup install nightly
-            rustup component add rustfmt --toolchain=nightly
-            # use +nightly to enable license_template check
-            cargo +nightly fmt --version
-            cargo +nightly fmt -- --check
+            # TODO: use +nightly to enable license_template check
+            cargo fmt --version
+            cargo fmt --check
       - run:
           name: cargo test
           command: |
@@ -51,8 +49,11 @@ jobs:
       - run:
           name: "Check 'no std' + crypto build"
           command: |
+            # check vanilla no std
             cargo --version --verbose
             cargo check --no-default-features
+            # check crypto + no std
+            rustup install nightly
             cargo +nightly --version --verbose
             cargo +nightly check --no-default-features --features=crypto
       # JS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,23 +39,25 @@ jobs:
       - run:
           name: cargo fmt
           command: |
-            cargo fmt --version
-            cargo fmt -- --check
+            # use +nightly to enable license_template check
+            cargo +nightly fmt --version
+            cargo +nightly fmt -- --check
       - run:
           name: cargo test
           command: |
             cargo test
       - run:
-          name: "Check 'no std' build"
+          name: "Check 'no std' + crypto build"
           command: |
             cargo --version --verbose
             cargo check --no-default-features
+            cargo +nightly check --no-default-features --features=crypto
       # JS
       - build-js
       - test-js
   publish-js:
     docker:
-      - image: circleci/rust:1.43.1
+      - image: circleci/rust:1.44.1
     steps:
       - checkout
       - build-js
@@ -67,7 +69,7 @@ jobs:
             npm publish --access public --tag next
   clippy:
     docker:
-      - image: circleci/rust:1.43.1
+      - image: circleci/rust:1.44.1
     steps:
       - checkout
       - run:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,7 @@ dependencies = [
 name = "doughnut_rs"
 version = "0.4.1"
 dependencies = [
+ "clear_on_drop",
  "ed25519-dalek",
  "parity-scale-codec",
  "primitive-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,13 @@ license = "UNLICENSED"
 repository = "https://github.com/cennznet/doughnut-rs"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "^1.3.0", default-features = false, features = ["derive"] }
 primitive-types = { version = "0.7.2", default-features = false }
-schnorrkel = { version = "0.9.1", optional = true }
-ed25519-dalek = { version = "1.0.0-pre.1", optional = true }
+schnorrkel = { version = "0.9.1", features = ["preaudit_deprecated", "u64_backend"], default-features = false, optional = true }
+ed25519-dalek = { version = "1.0.0-pre.3", default-features = false, features = ["u64_backend", "alloc"], optional = true }
+# including this fixes C build issues in consumer crates
+# see:
+clear_on_drop = { version = "0.2.3", features = ["no_cc"] }
 
 [dev-dependencies]
 rand = { version = "0.7.3", features = ["wasm-bindgen"] }
@@ -20,9 +23,16 @@ rand_core = { version = "0.5.1", features = ["alloc"] }
 [features]
 default = ["std"]
 std = [
+    "crypto",
     "ed25519-dalek/std",
-    "schnorrkel/std"
+    "schnorrkel/std",
 ]
+ # enable cryptographic signing and verification features in 'no std'
+crypto = [
+    "ed25519-dalek",
+    "schnorrkel"
+]
+# enable compilation for wasm-bindgen
 wasm = [
     "ed25519-dalek",
     "schnorrkel/wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ codec = { package = "parity-scale-codec", version = "^1.3.0", default-features =
 primitive-types = { version = "0.7.2", default-features = false }
 schnorrkel = { version = "0.9.1", features = ["preaudit_deprecated", "u64_backend"], default-features = false, optional = true }
 ed25519-dalek = { version = "1.0.0-pre.3", default-features = false, features = ["u64_backend", "alloc"], optional = true }
-# including this fixes C build issues in consumer crates
-# see:
+# including this to fix C build issues in consumer crates
+# 'No available targets are compatible with this triple.'
 clear_on_drop = { version = "0.2.3", features = ["no_cc"] }
 
 [dev-dependencies]
@@ -25,7 +25,7 @@ default = ["std"]
 std = [
     "crypto",
     "ed25519-dalek/std",
-    "schnorrkel/std",
+    "schnorrkel/std"
 ]
  # enable cryptographic signing and verification features in 'no std'
 crypto = [

--- a/README.md
+++ b/README.md
@@ -25,27 +25,43 @@ assert!(
 )
 ```
 
-Verify a doughnut's signature (requires `std`)
+Verify a doughnut's signature (requires `"crypto"` feature in `"no_std"` mode and rust nightly)
 ```rust
 use doughnut_rs::traits::DoughnutVerify;
 // ..
-assert!(doughnut.verify());
+assert!(doughnut.verify().is_ok());
+```
+
+Sign a doughnut (requires `"crypto"` feature in `"no_std"` mode and rust nightly)
+```rust
+use doughnut_rs::traits::Signing;
+let mut doughnut = DoughnutV0 { ... };
+// Schnorrkel
+assert!(doughnut.sign_sr25519(<secret_key_bytes>).is_ok());
+// Ed25519
+assert!(doughnut.sign_ed25519(<secret_key_bytes>).is_ok());
 ```
 
 # Contributing
 The following checks should pass  
 ```bash
 # Do the usual
-cargo fmt && \
+cargo +nightly fmt && \
 cargo check && \
 cargo test
 
 # Check 'no std' mode compiles
 cargo check --no-default-features
+
+# Check crypto functionality in 'no std' mode
+cargo +nightly check --no-default-features
 ```
 
 ## Generate JS/Wasm bindings
-This crate also provides generated JS bindings using [wasm-pack](https://rustwasm.github.io/docs/wasm-pack/). To generate the package run:
+This crate also provides generated JS bindings using [wasm-pack](https://rustwasm.github.io/docs/wasm-pack/).
+See the [js](js/README.md) dir for usage.
+
+To generate the package run:
 ```bash
 # install wasm pack
 curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
@@ -56,4 +72,3 @@ cd js/ && yarn build
 # Run tests
 yarn test
 ```
-

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,7 +25,7 @@ pub enum ValidationError {
 }
 
 /// A signature verification error
-#[cfg_attr(feature = "std", derive(PartialEq, Debug))]
+#[derive(PartialEq, Debug)]
 pub enum VerifyError {
     /// Unsupported signature version
     UnsupportedVersion,
@@ -38,7 +38,7 @@ pub enum VerifyError {
 }
 
 /// A signature signing error
-#[cfg_attr(feature = "std", derive(PartialEq, Debug))]
+#[derive(PartialEq, Debug)]
 pub enum SigningError {
     // Provided public/secret key is invalid ed25519 signing
     InvalidEd25519Key,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ mod doughnut;
 pub use doughnut::Doughnut;
 
 pub mod error;
-#[cfg(feature = "std")]
+#[cfg(feature = "crypto")]
 mod signature;
 mod test;
 pub mod traits;

--- a/src/signature/mod.rs
+++ b/src/signature/mod.rs
@@ -1,5 +1,6 @@
 // Copyright 2019-2020 Centrality Investments Limited
 
+use crate::alloc::vec::Vec;
 use crate::error::{SigningError, VerifyError};
 use core::convert::TryFrom;
 

--- a/src/traits/impls.rs
+++ b/src/traits/impls.rs
@@ -45,12 +45,12 @@ impl DoughnutApi for () {
 #[cfg(feature = "crypto")]
 pub mod crypto {
     //! Crypto.verification and signing impls for Doughnut types
-    use super::*;
     use crate::{
+        alloc::vec::Vec,
         doughnut::Doughnut,
         error::{SigningError, VerifyError},
         signature::{sign_ed25519, sign_sr25519, verify_signature, SignatureVersion},
-        traits::Signing,
+        traits::{DoughnutApi, DoughnutVerify, Signing},
         v0::DoughnutV0,
     };
     use primitive_types::H512;

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -4,8 +4,10 @@
 //! Doughnut traits
 //!
 
-use crate::alloc::vec::Vec;
-use crate::error::{SigningError, ValidationError, VerifyError};
+use crate::{
+    alloc::vec::Vec,
+    error::{SigningError, ValidationError, VerifyError},
+};
 use core::convert::TryInto;
 
 mod impls;
@@ -66,6 +68,7 @@ pub trait DoughnutApi {
     }
 }
 
+/// Provide doughnut signing
 pub trait Signing {
     /// sign using Ed25519 method
     fn sign_ed25519(&mut self, secret_key: &[u8]) -> Result<Vec<u8>, SigningError>;

--- a/src/v0/mod.rs
+++ b/src/v0/mod.rs
@@ -236,8 +236,10 @@ impl Decode for DoughnutV0 {
 mod test {
     use super::*;
     use crate::error::ValidationError;
-    use std::ops::Add;
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use std::{
+        ops::Add,
+        time::{Duration, SystemTime, UNIX_EPOCH},
+    };
 
     macro_rules! doughnut_builder {
         (


### PR DESCRIPTION
ed25519 crate now provides 'no_std' support
This PR provides 'no_std' signing and verification moving it behind the cargo "crypto" feature.
It is included in "std" build by default.

The main motivation for doing this is to allow crypto/signature checks to happen inside this crate when running 'no_std'.
We can then remove that functionality from Plug (which used to require special handling see: plugblockchain/plug-blockchain#110)

Misc:
- Add crypto build check to CI and bump stable version
- Grouped some `use` imports
- Missing doc string
- Fix README example `verify()` usage and add signing
