### PR TITLE
Remove extraneous bytes check on input buffer

### DIFF
--- a/src/v0/mod.rs
+++ b/src/v0/mod.rs
@@ -575,8 +575,6 @@ mod test {
         );
     }
 
-    // TODO: reconcile once https://github.com/cennznet/doughnut-rs/issues/67 is solved
-    #[ignore]
     #[test]
     fn decode_error_with_too_many_bytes() {
         let doughnut = doughnut_builder!();
@@ -585,10 +583,11 @@ mod test {
 
         let result = DoughnutV0::decode(&mut &encoded[..]);
 
-        assert_eq!(
-            result,
-            Err(codec::Error::from("Doughnut contains unexpected bytes"))
-        );
+        // This used to be a decoding error.
+        // It may be desirable for some use cases to fail when encountering extraneous bytes
+        // as a security precaution.
+        // TODO: reconcile with https://github.com/cennznet/doughnut-rs/issues/67
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/src/v0/mod.rs
+++ b/src/v0/mod.rs
@@ -215,20 +215,16 @@ impl Decode for DoughnutV0 {
         let mut signature = [0_u8; 64];
         input.read(&mut signature)?;
 
-        if input.read_byte().is_ok() {
-            Err(codec::Error::from("Doughnut contains unexpected bytes"))
-        } else {
-            Ok(Self {
-                holder,
-                issuer,
-                expiry,
-                not_before,
-                signature_version,
-                payload_version,
-                domains,
-                signature: H512::from(signature),
-            })
-        }
+        Ok(Self {
+            holder,
+            issuer,
+            expiry,
+            not_before,
+            signature_version,
+            payload_version,
+            domains,
+            signature: H512::from(signature),
+        })
     }
 }
 
@@ -579,6 +575,8 @@ mod test {
         );
     }
 
+    // TODO: reconcile once https://github.com/cennznet/doughnut-rs/issues/67 is solved
+    #[ignore]
     #[test]
     fn decode_error_with_too_many_bytes() {
         let doughnut = doughnut_builder!();


### PR DESCRIPTION
Fixes issue with decoding failing when `input` buffer contains other bytes e.g. plug/cennznet extrinsics.
This check could be re-introduced as an option with #67